### PR TITLE
Fix documentation link on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT"
 description = "Range support for rust-postgres"
 repository = "https://github.com/sfackler/rust-postgres-range"
-documentation = "https://sfackler.github.io/doc/postgres_range"
+documentation = "https://sfackler.github.io/rust-postgres-range/doc/postgres_range"
 
 [dependencies]
 time = "0.1"


### PR DESCRIPTION
The old one returned 404.
