### PR TITLE
Adding `Normalizable` implementation for NaiveDateTime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate chrono;
 extern crate postgres;
 
 #[cfg(feature = "with-chrono")]
-use chrono::{DateTime, TimeZone};
+use chrono::{DateTime, NaiveDateTime, TimeZone};
 use std::cmp::Ordering;
 use std::fmt;
 use std::i32;
@@ -176,6 +176,16 @@ impl<T> Normalizable for DateTime<T>
     }
 }
 
+#[cfg(feature = "with-chrono")]
+impl Normalizable for NaiveDateTime
+{
+    fn normalize<S>(bound: RangeBound<S, NaiveDateTime>) -> RangeBound<S, NaiveDateTime>
+    where
+        S: BoundSided,
+    {
+        bound
+    }
+}
 
 /// The possible sides of a bound.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
This makes it possible represent a range of chrono::NaiveDateTime, which
is what rust-postgres maps to for tsrange columns without timezone.