### PR TITLE
Disable chrono's default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ with-chrono-0_4 = ["chrono-04", "postgres-types/with-chrono-0_4"]
 [dependencies]
 postgres-protocol = "0.6"
 postgres-types = "0.2"
-chrono-04 = { version = "0.4", package = "chrono", optional = true }
+chrono-04 = { version = "0.4", package = "chrono", optional = true, default-features = false }
 
 [dev-dependencies]
 postgres = "0.19"


### PR DESCRIPTION
This fixes invocations of `cargo audit`, where the unnecessary `time` dependency is pulled in.

Before:

```
❯ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 464 security advisories (from /Users/msepga/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (106 crate dependencies)
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.22
    ├── postgres_range 0.11.0
    └── postgres-types 0.2.4
        ├── tokio-postgres 0.7.7
        │   └── postgres 0.19.4
        │       └── postgres_range 0.11.0
        └── postgres_range 0.11.0

error: 1 vulnerability found!
```

After:

```
❯ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 464 security advisories (from /Users/msepga/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (104 crate dependencies)
```