### PR TITLE
Support Range<NaiveDate> for daterange

### DIFF
--- a/src/chrono_04.rs
+++ b/src/chrono_04.rs
@@ -22,13 +22,4 @@ impl Normalizable for NaiveDateTime
     }
 }
 
-
-impl Normalizable for NaiveDate
-{
-    fn normalize<S>(bound: RangeBound<S, NaiveDate>) -> RangeBound<S, NaiveDate>
-    where
-        S: BoundSided,
-    {
-        bound
-    }
-}
+bounded_normalizable!(NaiveDate, ::chrono_04::Duration::days(1));

--- a/src/chrono_04.rs
+++ b/src/chrono_04.rs
@@ -1,4 +1,4 @@
-use chrono_04::{DateTime, NaiveDateTime, TimeZone, NaiveDate, NaiveTime};
+use chrono_04::{DateTime, NaiveDateTime, TimeZone, NaiveDate};
 
 use crate::{Normalizable, RangeBound, BoundSided};
 
@@ -26,16 +26,6 @@ impl Normalizable for NaiveDateTime
 impl Normalizable for NaiveDate
 {
     fn normalize<S>(bound: RangeBound<S, NaiveDate>) -> RangeBound<S, NaiveDate>
-    where
-        S: BoundSided,
-    {
-        bound
-    }
-}
-
-impl Normalizable for NaiveTime
-{
-    fn normalize<S>(bound: RangeBound<S, NaiveTime>) -> RangeBound<S, NaiveTime>
     where
         S: BoundSided,
     {

--- a/src/chrono_04.rs
+++ b/src/chrono_04.rs
@@ -1,4 +1,4 @@
-use chrono_04::{DateTime, NaiveDateTime, TimeZone};
+use chrono_04::{DateTime, NaiveDateTime, TimeZone, NaiveDate, NaiveTime};
 
 use crate::{Normalizable, RangeBound, BoundSided};
 
@@ -15,6 +15,27 @@ impl<T> Normalizable for DateTime<T>
 impl Normalizable for NaiveDateTime
 {
     fn normalize<S>(bound: RangeBound<S, NaiveDateTime>) -> RangeBound<S, NaiveDateTime>
+    where
+        S: BoundSided,
+    {
+        bound
+    }
+}
+
+
+impl Normalizable for NaiveDate
+{
+    fn normalize<S>(bound: RangeBound<S, NaiveDate>) -> RangeBound<S, NaiveDate>
+    where
+        S: BoundSided,
+    {
+        bound
+    }
+}
+
+impl Normalizable for NaiveTime
+{
+    fn normalize<S>(bound: RangeBound<S, NaiveTime>) -> RangeBound<S, NaiveTime>
     where
         S: BoundSided,
     {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -173,15 +173,15 @@ mod test {
     #[test]
     #[cfg(feature = "with-chrono-0_4")]
     fn test_tsrange_params() {
-        let low = Utc.timestamp(0, 0);
+        let low = NaiveDateTime::from_timestamp_opt(0, 0).unwrap();
         let high = low + Duration::days(10);
-        test_range!("TSRANGE", NaiveDateTime, low.naive_utc(), "1970-01-01", high.naive_utc(), "1970-01-11");
+        test_range!("TSRANGE", NaiveDateTime, low, "1970-01-01", high, "1970-01-11");
     }
 
     #[test]
     #[cfg(feature = "with-chrono-0_4")]
     fn test_tstzrange_params() {
-        let low = Utc.timestamp(0, 0);
+        let low = Utc.timestamp_opt(0, 0).unwrap();
         let high = low + Duration::days(10);
         test_range!("TSTZRANGE", DateTime<Utc>, low, "1970-01-01", high, "1970-01-11");
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -188,4 +188,14 @@ mod test {
         let high = low + Duration::days(10);
         test_range!("TSTZRANGE", DateTime<_>, low, "2014-07-08T09:10:11Z", high, "2014-07-18T09:10:11Z");
     }
+
+
+    #[test]
+    #[cfg(feature = "with-chrono-0_4")]
+    #[ignore = "Exclusive starts will be converted to next-day + inclusive"]
+    fn test_daterange_params() {
+        let low = NaiveDate::from_ymd_opt(2015, 6, 4).unwrap();
+        let high = low + Duration::days(10);
+        test_range!("DATERANGE", NaiveDate, low, "2015-06-04", high, "2015-06-14");
+    }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -152,11 +152,11 @@ mod test {
             let stmt = conn.prepare(&*format!("SELECT {}::{}", *repr, sql_type))
                 .unwrap();
             let result = conn.query(&stmt, &[]).unwrap().iter().next().unwrap().get(0);
-            assert!(val == &result);
+            assert_eq!(val, &result);
 
             let stmt = conn.prepare(&*format!("SELECT $1::{}", sql_type)).unwrap();
             let result = conn.query(&stmt, &[val]).unwrap().iter().next().unwrap().get(0);
-            assert!(val == &result);
+            assert_eq!(val, &result);
         }
     }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -144,7 +144,7 @@ mod test {
 
     fn test_type<T, S>(sql_type: &str, checks: &[(T, S)])
     where for<'a>
-        T: Sync + PartialEq + FromSql<'a> + ToSql,
+        T: Sync + PartialEq + FromSql<'a> + ToSql + fmt::Debug,
         S: fmt::Display
     {
         let mut conn = Client::connect("postgres://postgres@localhost", NoTls).unwrap();
@@ -152,11 +152,11 @@ mod test {
             let stmt = conn.prepare(&*format!("SELECT {}::{}", *repr, sql_type))
                 .unwrap();
             let result = conn.query(&stmt, &[]).unwrap().iter().next().unwrap().get(0);
-            assert_eq!(val, &result);
+            assert_eq!(val, &result, "'SELECT {repr}::{sql_type}'");
 
             let stmt = conn.prepare(&*format!("SELECT $1::{}", sql_type)).unwrap();
             let result = conn.query(&stmt, &[val]).unwrap().iter().next().unwrap().get(0);
-            assert_eq!(val, &result);
+            assert_eq!(val, &result, "'SELECT $1::{sql_type}'");
         }
     }
 
@@ -192,7 +192,6 @@ mod test {
 
     #[test]
     #[cfg(feature = "with-chrono-0_4")]
-    #[ignore = "Exclusive starts will be converted to next-day + inclusive"]
     fn test_daterange_params() {
         let low = NaiveDate::from_ymd_opt(2015, 6, 4).unwrap();
         let high = low + Duration::days(10);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -118,7 +118,7 @@ mod test {
     use postgres::{Client, NoTls};
     use postgres::types::{FromSql, ToSql};
     #[cfg(feature = "with-chrono-0_4")]
-    use chrono_04::{TimeZone, Utc, Duration};
+    use chrono_04::{NaiveDate, NaiveTime, NaiveDateTime, TimeZone, Utc, Duration};
 
     macro_rules! test_range {
         ($name:expr, $t:ty, $low:expr, $low_str:expr, $high:expr, $high_str:expr) => ({
@@ -173,16 +173,19 @@ mod test {
     #[test]
     #[cfg(feature = "with-chrono-0_4")]
     fn test_tsrange_params() {
-        let low = NaiveDateTime::from_timestamp_opt(0, 0).unwrap();
+        let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+        let t = NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
+
+        let low = NaiveDateTime::new(d, t);
         let high = low + Duration::days(10);
-        test_range!("TSRANGE", NaiveDateTime, low, "1970-01-01", high, "1970-01-11");
+        test_range!("TSRANGE", NaiveDateTime, low, "2015-06-03T12:34:56.789", high, "2015-06-13T12:34:56.789");
     }
 
     #[test]
     #[cfg(feature = "with-chrono-0_4")]
     fn test_tstzrange_params() {
-        let low = Utc.timestamp_opt(0, 0).unwrap();
+        let low = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap();
         let high = low + Duration::days(10);
-        test_range!("TSTZRANGE", DateTime<Utc>, low, "1970-01-01", high, "1970-01-11");
+        test_range!("TSTZRANGE", DateTime<_>, low, "2014-07-08T09:10:11Z", high, "2014-07-18T09:10:11Z");
     }
 }


### PR DESCRIPTION
This implements `Normalizable` for `NaiveDate` to support `Range<Date>`. It also changes `assert!` to `assert_eq!` in a few places to improve the test output. 

Note that I had to `#[ignore]` the new test I added because Postgres normalises `(2023-01-01,)` to `[2023-01-02,)`, which makes the test fail as `test_types` does a by-value comparison. 